### PR TITLE
RNN.py : indicate step number, cost, and loss

### DIFF
--- a/09 - RNN/RNN.py
+++ b/09 - RNN/RNN.py
@@ -45,4 +45,4 @@ with tf.Session() as sess:
     for i in range(100):
         sess.run(train_op)
         result = sess.run(tf.arg_max(logits, 1))
-        print("%r, %r" % (result, [char_rdic[t] for t in result]))
+        print("%d, %g, %r, %r" % (i, cost.eval(), result, zip([char_rdic[t] for t in result], loss.eval())))


### PR DESCRIPTION
RNN.py 파일의 반복문 출력부에 i 값과 cost, loss 값을 같이 표시 해 보았습니다.  저는 출력값이 더 가까와짐에 따라 cost 값이나 loss 값이 뚜렷하게 감소하지는 않는 것으로 보이는데 맞게 이해하고 있는 것인지요? (아래에서 50 -> 51)

47, 3.43674, array([2, 2, 2, 3]), [('l', 1.0350623), ('l', 0.65742505), ('l', 0.85237312), ('o', 0.89187962)]
48, 3.39462, array([2, 2, 2, 3]), [('l', 1.0225992), ('l', 0.64655399), ('l', 0.84642881), ('o', 0.87903702)]
49, 3.35311, array([2, 2, 2, 3]), [('l', 1.0101602), ('l', 0.63608557), ('l', 0.84065008), ('o', 0.86621475)]
50, 3.31215, array([2, 2, 2, 3]), [('l', 0.99774575), ('l', 0.62600297), ('l', 0.83500803), ('o', 0.85339618)]
51, 3.27169, array([1, 2, 2, 3]), [('e', 0.98535264), ('l', 0.61628914), ('l', 0.82947683), ('o', 0.84056687)]
52, 3.23166, array([1, 2, 2, 3]), [('e', 0.97297615), ('l', 0.60692823), ('l', 0.82403302), ('o', 0.82771838)]
53, 3.19202, array([1, 2, 2, 3]), [('e', 0.96061027), ('l', 0.59790409), ('l', 0.81865412), ('o', 0.81484872)]
54, 3.15273, array([1, 2, 2, 3]), [('e', 0.9482488), ('l', 0.58920062), ('l', 0.81331855), ('o', 0.80196536)]
55, 3.11378, array([1, 2, 2, 3]), [('e', 0.93588698), ('l', 0.58080173), ('l', 0.80800408), ('o', 0.78908801)]
